### PR TITLE
fix: Cleaning up examples by refactoring out locals

### DIFF
--- a/examples/terragrunt/stacks/stateful-asg-service/terragrunt.stack.hcl
+++ b/examples/terragrunt/stacks/stateful-asg-service/terragrunt.stack.hcl
@@ -1,4 +1,8 @@
 locals {
+  name = "stateful-asg-service"
+
+  # NOTE: This is only defined here to make this example simple.
+  # Don't actually store credentials for your DB in plain text!
   db_username = "admin"
   db_password = "password"
 }
@@ -13,7 +17,7 @@ unit "service" {
     // to use when fetching the OpenTofu/Terraform module.
     version = "main"
 
-    name          = "stateful-asg-service"
+    name          = local.name
     instance_type = "t4g.micro"
     min_size      = 2
     max_size      = 4
@@ -40,7 +44,7 @@ unit "db" {
     // to use when fetching the OpenTofu/Terraform module.
     version = "main"
 
-    name              = "ec2statefuldb"
+    name              = "${replace(local.name, "-", "")}db"
     instance_class    = "db.t4g.micro"
     allocated_storage = 20
     storage_type      = "gp2"
@@ -66,7 +70,7 @@ unit "asg_sg" {
     // to use when fetching the OpenTofu/Terraform module.
     version = "main"
 
-    name = "stateful-asg-service-asg-sg"
+    name = "${local.name}-asg-sg"
   }
 }
 

--- a/examples/terragrunt/stacks/stateful-ecs-service/terragrunt.stack.hcl
+++ b/examples/terragrunt/stacks/stateful-ecs-service/terragrunt.stack.hcl
@@ -63,7 +63,7 @@ unit "db" {
     // to use when fetching the OpenTofu/Terraform module.
     version = "main"
 
-    name              = "ecsstatefuldb"
+    name              = "${replace(local.name, "-", "")}db"
     instance_class    = "db.t4g.micro"
     allocated_storage = 20
     storage_type      = "gp2"

--- a/stacks/ec2-asg-stateful-service/terragrunt.stack.hcl
+++ b/stacks/ec2-asg-stateful-service/terragrunt.stack.hcl
@@ -1,4 +1,8 @@
 locals {
+  name = values.name
+
+  # NOTE: This is only defined here to make this example simple.
+  # Don't actually store credentials for your DB in plain text!
   db_username = values.db_username
   db_password = values.db_password
 }
@@ -19,7 +23,7 @@ unit "service" {
   values = {
     version = values.version
 
-    name          = values.name
+    name          = local.name
     instance_type = values.instance_type
     min_size      = values.min_size
     max_size      = values.max_size
@@ -54,7 +58,7 @@ unit "db" {
   values = {
     version = values.version
 
-    name              = values.name
+    name              = "${replace(local.name, "-", "")}db"
     instance_class    = values.instance_class
     allocated_storage = values.allocated_storage
     storage_type      = values.storage_type
@@ -76,7 +80,7 @@ unit "asg_sg" {
   values = {
     version = values.version
 
-    name = "${values.name}-asg-sg"
+    name = "${local.name}-asg-sg"
   }
 }
 


### PR DESCRIPTION
This cleans up the examples a bit by refactoring out the `name` value into a local that can be sanitized for usage in the database name.

